### PR TITLE
Add api_flashcards engine

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,3 +49,5 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'webmock'
 end
+
+gem 'api_flashcards', git: 'https://github.com/belovamarina/api_flashcards', branch: 'auth'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: https://github.com/belovamarina/api_flashcards
+  revision: 0018b79f85e11f3da4495ea2864bde762b67ffcf
+  branch: auth
+  specs:
+    api_flashcards (0.1.0)
+      rails (~> 5.1)
+      sorcery
+
+GIT
   remote: https://github.com/sudosu/rails_admin_pundit
   revision: 8e3e750a3df5ce41722480494079968915ae84ce
   specs:
@@ -320,6 +329,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  api_flashcards!
   byebug
   capybara
   carrierwave

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
+  mount ApiFlashcards::Engine => '/api'
   filter :locale
 
   root to: 'main#index'

--- a/spec/features/api_spec.rb
+++ b/spec/features/api_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.feature 'Access to API main page', type: :feature do
+  let(:user) { create(:user) }
+
+  scenario 'user login with HTTP Basic auth' do
+    page.driver.browser.basic_authorize(user.email, '12345')
+    visit api_flashcards_path
+    expect(page).to have_content 'Welcome'
+  end
+
+  scenario 'anonim try to visit api page' do
+    visit api_flashcards_path
+    expect(page).not_to have_content 'Welcome'
+  end
+end


### PR DESCRIPTION
1. Создать Rails Engine с названием api_flashcards. Создать для этого Engine отдельный репозиторий. В отдельной ветке добавить защиту в виде HTTP Basic Auth:
https://github.com/belovamarina/api_flashcards/tree/auth

2. Что делать если кто-то пытается устроить brute force взлом HTTP Basic Auth нашего engine?
Поставить задержку (для одного пользователя будет незаметно, а скрипт замедлится) или поменять http basic на другой способ (блокировать аккаунт после нескольких неудачных попыток или ввести токены для авторизации)